### PR TITLE
Revert "build(deps): bump bootstrap from 4.6.2 to 5.0.0 in /client"

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
     "aurelia-slickgrid": "^6.3.0",
     "aurelia-validation": "2.0.0",
     "autoprefixer": "^10.4.14",
-    "bootstrap": "^5.0.0",
+    "bootstrap": "^4.6.2",
     "bootstrap-social": "^5.1.1",
     "font-awesome": "^4.7.0",
     "i18next": "^21.10.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2564,10 +2564,10 @@ bootstrap-social@^5.1.1:
     bootstrap "~3"
     font-awesome "~4.7"
 
-bootstrap@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.0.tgz#97635ac0e0d6cb466700ebf0fd266bfabf352ed2"
-  integrity sha512-tmhPET9B9qCl8dCofvHeiIhi49iBt0EehmIsziZib65k1erBW1rHhj2s/2JsuQh5Pq+xz2E9bEbzp9B7xHG+VA==
+bootstrap@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.2.tgz#8e0cd61611728a5bf65a3a2b8d6ff6c77d5d7479"
+  integrity sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==
 
 bootstrap@~3:
   version "3.4.1"


### PR DESCRIPTION
Reverts ghiscoding/aurelia-nest-auth-mongodb#114 since I merged too fast and only saw after that it was a major version which the bot should have never proposed